### PR TITLE
Add windows-11-build to link

### DIFF
--- a/src/NinjaCatDiscordBot/NinjaCatDiscordClient.cs
+++ b/src/NinjaCatDiscordBot/NinjaCatDiscordClient.cs
@@ -393,7 +393,7 @@ namespace NinjaCatDiscordBot {
                     // Get page.
                     var doc = XDocument.Parse(await httpClient.GetStringAsync($"https://blogs.windows.com/windows-insider/feed/?paged={page}"));
                     var entries = from item in doc.Root.Descendants().First(i => i.Name.LocalName == "channel").Elements().Where(i => i.Name.LocalName == "item")
-                                  where item.Elements().First(i => i.Name.LocalName == "link").Value.ToLowerInvariant().ContainsAny("insider-preview", "windows-10-build")
+                                  where item.Elements().First(i => i.Name.LocalName == "link").Value.ToLowerInvariant().ContainsAny("insider-preview", "windows-10-build", "windows-11-build")
                                   select item;
                     var posts = entries.Select(async item => await BlogEntry.Create(
                             httpClient,


### PR DESCRIPTION
Ninja Cat doesn't check if `windows-11-build` is in the build links, leading to builds like 22000.348 being totally ignored.